### PR TITLE
Style/tickets

### DIFF
--- a/src/components/atomic/atoms/content-meta-data-render-component.tsx
+++ b/src/components/atomic/atoms/content-meta-data-render-component.tsx
@@ -1,27 +1,20 @@
-import { ComponentRenderFunc } from "../../../types";
+import { Typography } from "@mui/material";
+import { marked } from "marked";
+import { PropsWithChildren, useCallback, useMemo } from "react";
+
 import {
   ContentFormatType,
   ContentMetadata,
 } from "../../../__generated__/graphql";
-import {
-  PropsWithChildren,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
-import { Box, Stack, Typography } from "@mui/material";
 import StringHelper from "../../../helper/string-helper";
-import { marked } from "marked";
-import LinkTypography from "./link-typography";
+import { ComponentRenderFunc } from "../../../types";
 
 marked.use({
   gfm: true,
   breaks: true,
 });
 
-const MarkDownRenderer = ({
+export const MarkDownRenderer = ({
   content,
 }: { content?: string } & PropsWithChildren) => {
   const html = useMemo(() => {

--- a/src/components/pages/event/event-description.tsx
+++ b/src/components/pages/event/event-description.tsx
@@ -1,15 +1,17 @@
-import { Ticket } from "../../../types";
-import React, { PropsWithChildren } from "react";
 import { Box, Stack, Typography, useMediaQuery } from "@mui/material";
-import ContentMetaDataRenderComponent from "../../atomic/atoms/content-meta-data-render-component";
 import { useTheme } from "@mui/material/styles";
-import ComponentHelper from "../../../helper/component-helper";
 
-const EventDescription = (
-  props: { ticketData?: Ticket } & PropsWithChildren
-) => {
-  const { ticketData } = props;
+import ContentMetaDataRenderComponent, {
+  MarkDownRenderer,
+} from "@/components/atomic/atoms/content-meta-data-render-component";
+import ComponentHelper from "@/helper/component-helper";
+import { Ticket } from "@/types";
 
+interface EventDescriptionProps {
+  ticketData?: Ticket;
+}
+
+const EventDescription = ({ ticketData }: EventDescriptionProps) => {
   const theme = useTheme();
   const smUp = useMediaQuery(theme.breakpoints.up("sm"));
   const mdUp = useMediaQuery(theme.breakpoints.up("md"));
@@ -44,6 +46,13 @@ const EventDescription = (
                   __html: content ?? "<></>",
                 }}
               ></div>
+            );
+          }}
+          markComponentFunc={(content) => {
+            return (
+              <div className="text-center md:text-left">
+                <MarkDownRenderer content={content} />
+              </div>
             );
           }}
         ></ContentMetaDataRenderComponent>

--- a/src/components/pages/event/event-description.tsx
+++ b/src/components/pages/event/event-description.tsx
@@ -1,5 +1,6 @@
 import { Box, Stack, Typography, useMediaQuery } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
+import { PropsWithChildren } from "react";
 
 import ContentMetaDataRenderComponent, {
   MarkDownRenderer,
@@ -11,7 +12,10 @@ interface EventDescriptionProps {
   ticketData?: Ticket;
 }
 
-const EventDescription = ({ ticketData }: EventDescriptionProps) => {
+const EventDescription = ({
+  ticketData,
+}: // FIXME: children prop is not used
+PropsWithChildren<EventDescriptionProps>) => {
   const theme = useTheme();
   const smUp = useMediaQuery(theme.breakpoints.up("sm"));
   const mdUp = useMediaQuery(theme.breakpoints.up("md"));

--- a/src/hooks/util/use-query.ts
+++ b/src/hooks/util/use-query.ts
@@ -1,15 +1,15 @@
-import {
+import type {
   DocumentNode,
   OperationVariables,
   QueryHookOptions,
   QueryResult,
   TypedDocumentNode,
-  useQuery as useQueryOrigin,
 } from "@apollo/client";
+import { useQuery as useQueryOrigin } from "@apollo/client";
 
-export const useQuery = <Data = any, Variables = OperationVariables>(
+export const useQuery = <Data = unknown, Variables = OperationVariables>(
   query: DocumentNode | TypedDocumentNode<Data, Variables>,
-  options?: QueryHookOptions<Data, Variables>
+  options?: QueryHookOptions<Data, Variables>,
 ): QueryResult<Data, Variables> => {
   const shouldSkip = () => {
     const { variables } = options ?? {};

--- a/src/hooks/util/use-query.ts
+++ b/src/hooks/util/use-query.ts
@@ -1,0 +1,29 @@
+import {
+  DocumentNode,
+  OperationVariables,
+  QueryHookOptions,
+  QueryResult,
+  TypedDocumentNode,
+  useQuery as useQueryOrigin,
+} from "@apollo/client";
+
+export const useQuery = <Data = any, Variables = OperationVariables>(
+  query: DocumentNode | TypedDocumentNode<Data, Variables>,
+  options?: QueryHookOptions<Data, Variables>
+): QueryResult<Data, Variables> => {
+  const shouldSkip = () => {
+    const { variables } = options ?? {};
+
+    if (options?.skip) return true;
+    if (!variables) return options?.skip;
+
+    const [_values, _keys] = [Object.values(variables), Object.keys(variables)];
+
+    const definedValues = _values.filter((value) => value !== undefined);
+    return definedValues.length !== _keys.length;
+  };
+
+  const isSkip = shouldSkip();
+
+  return useQueryOrigin(query, { ...options, skip: isSkip });
+};

--- a/src/util/md-parser.ts
+++ b/src/util/md-parser.ts
@@ -1,0 +1,14 @@
+import { marked, Marked } from "marked";
+
+const defaultOptions: marked.MarkedOptions = {
+  breaks: true,
+};
+
+const _marked = new Marked(defaultOptions);
+
+export const mdParser = (
+  content: string,
+  extraOptions?: marked.MarkedOptions,
+) => {
+  return _marked.parse(content, extraOptions);
+};

--- a/src/util/object-util.ts
+++ b/src/util/object-util.ts
@@ -1,0 +1,19 @@
+export class ObjectUtils {
+  public static entries<T extends object>(obj: T) {
+    return Object.entries(obj) as [keyof T, T[keyof T]][];
+  }
+
+  public static keys<T extends object>(obj: T) {
+    return Object.keys(obj) as (keyof T)[];
+  }
+
+  public static values<T extends object>(obj: T) {
+    return Object.values(obj) as T[keyof T][];
+  }
+
+  public static fromEntries<T extends object>(
+    entries: [keyof T, T[keyof T]][]
+  ) {
+    return Object.fromEntries(entries) as T;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,8 +13,8 @@ module.exports = {
     extend: {
       screens: {
         sm: "600px",
-        md: "960px",
-        lg: "1280px",
+        md: "1000px",
+        lg: "1200px",
         xl: "1920px",
       },
       colors: {


### PR DESCRIPTION
issue : #193

내용: 모바일 환경에서 이벤트 상세페이지 이벤트 설명을 중앙정렬

- content render component 에서 markdown 렌더링 추가설정을 위해 컴포넌트 export를 추가했습니다.
- event description 컴포넌트에서 ContentRenderer 컴포넌트를 커스텀 css를 추가해서 수정했습니다.
- apollo client에서 variables가 있는 경우, variables의 모든 value가 정의되지않으면 요청을 보내지않는 커스텀 기능을 담아서 기존 useQuery를 감싼 hook을 만들었습니다.
  - 아직 미적용 상태입니다.
- typesafe한 Object 유틸 클래스를 만들었습니다.
- tailwindcss config를 기존 테마 룰에 맞게 수정했습니다.
- marked 라이브러리 기본옵션을 포함한 parser 함수를 추가했습니다.