### PR TITLE
fix(#224): delete curtain element to sub-menu-button

### DIFF
--- a/src/components/atomic/molecules/sub-menu-button.tsx
+++ b/src/components/atomic/molecules/sub-menu-button.tsx
@@ -62,7 +62,7 @@ const SubMenuButton = (
     onProjectsClick?: MouseEventHandler;
     onLeaderBoardClick?: MouseEventHandler;
     onSignInClick?: MouseEventHandler;
-  }
+  },
 ) => {
   const theme = useTheme();
   const [open, setOpen] = useState(false);
@@ -75,9 +75,6 @@ const SubMenuButton = (
         cursor: "pointer",
         "&:hover": {
           color: "white",
-          "& .curtain": {
-            backgroundColor: theme.palette.action.hover,
-          },
         },
       }}
       onClick={(event: MouseEvent) => {
@@ -93,15 +90,14 @@ const SubMenuButton = (
           borderRadius: 2,
           padding: 1,
           "&:hover": {
-            backgroundColor: theme.palette.secondary.main,
-            // borderBottomColor: theme.palette.action.selected,
+            backgroundColor: theme.palette.action.hover,
           },
         }}
       >
         <MoreHorizIcon
           sx={{
             color: "white",
-            "&:hover": {
+            "*:hover > &": {
               color: theme.palette.neutral["900"],
             },
           }}
@@ -151,16 +147,6 @@ const SubMenuButton = (
           </Stack>
         </StyledMenuItem>
       </StyledMenu>
-      <div
-        className={"curtain"}
-        style={{
-          position: "absolute",
-          marginTop: -32,
-          width: 32,
-          height: 32,
-          borderRadius: 32,
-        }}
-      ></div>
     </Box>
   );
 };


### PR DESCRIPTION
반응형 레이아웃 일때 우상단 토스트 버튼에 생기는 불투명 흰색 객체 이슈를 해결합니다 (#224)

navbar-avatar 컴포넌트에서 사용하던 요소가 원인으로 추정됩니다
https://github.com/DeSpread/3ridge-frontend/blob/2ae0a67498f7b30421971f1bc8eb47298a6d5379/src/components/atomic/molecules/navbar-avatar.tsx#L179-L188

- 해당 객체를 삭제했으며, 다른 스타일과 맞추기 위해 호버시 색상을 `theme.palette.secondary.main` 에서 `theme.palette.action.hover` 으로 변경했습니다
- 또한 버튼 내부의 아이콘의 색상이 버튼에 호버시가 아닌, 아이콘 영역에 직접 호버할시만 변경되는 이슈를 같이 수정했습니다.


closes #224 