### PR TITLE
feat: modify printed reward limit number

### DIFF
--- a/src/components/pages/event/reward/description/event-reward-limit-number.tsx
+++ b/src/components/pages/event/reward/description/event-reward-limit-number.tsx
@@ -2,9 +2,10 @@ import { Ticket } from "../../../../../types";
 import { PropsWithChildren } from "react";
 import { Stack, Typography } from "@mui/material";
 import StringHelper from "../../../../../helper/string-helper";
+import { RewardPolicyType } from "@/__generated__/graphql";
 
 const EventRewardLimitNumber = (
-  props: { ticketData?: Ticket } & PropsWithChildren
+  props: { ticketData?: Ticket } & PropsWithChildren,
 ) => {
   const { ticketData } = props;
 
@@ -18,9 +19,12 @@ const EventRewardLimitNumber = (
       <Typography variant={"body1"}>대상자 수</Typography>
       <Stack direction={"row"} alignItems={"center"}>
         <Typography variant={"body1"}>
-          {StringHelper.getRewardAmountLabel(
-            ticketData?.rewardPolicy?.context?.limitNumber
-          )}
+          {ticketData?.rewardPolicy?.rewardPolicyType ===
+          RewardPolicyType.Always
+            ? "-"
+            : StringHelper.getRewardAmountLabel(
+                ticketData?.rewardPolicy?.context?.limitNumber,
+              )}
         </Typography>
       </Stack>
     </Stack>

--- a/src/pages/admin/event/[id].tsx
+++ b/src/pages/admin/event/[id].tsx
@@ -670,15 +670,21 @@ const Event = () => {
           showLoading();
           const rewardPolicy = { ...ticketData?.rewardPolicy };
           rewardPolicy.rewardPolicyType = _rewardPolicyType;
-          const newRewardPolicy =
-            TypeHelper.convertToServerRewardPolicy(rewardPolicy);
-          await asyncUpdateTicketRewardPolicy(newRewardPolicy);
-          if (newRewardPolicy.rewardPolicyType === RewardPolicyType.Always) {
+
+          if (rewardPolicy.rewardPolicyType === RewardPolicyType.Always) {
+            if (rewardPolicy.context?.limitNumber !== undefined) {
+              rewardPolicy.context.limitNumber = 4294967296;
+            }
+
             await asyncUpdateTicketDateRangeTime(
               DateUtil.parseStrToDate(ticketData?.beginTime ?? ""),
               new Date(2099, 12, 31),
             );
           }
+
+          const newRewardPolicy =
+            TypeHelper.convertToServerRewardPolicy(rewardPolicy);
+          await asyncUpdateTicketRewardPolicy(newRewardPolicy);
           await asyncRefreshAll();
           setOpenTicketRewardPolicyEditDialog(false);
           closeLoading();


### PR DESCRIPTION
[슬랙 링크](https://despreadhq.slack.com/archives/C04GV1TQK8X/p1698389531125599?thread_ts=1698388753.511219&cid=C04GV1TQK8X)

리워드 정책이 상시 일 시, 대상자 수를 '-'로 표기합니다
rewardPolicy.context.limitNumber 는 4294967296 로 변경합니다
