### PR TITLE
feat: modify editable to date range when rewardPolicyType is always

### DIFF
--- a/src/pages/admin/event/[id].tsx
+++ b/src/pages/admin/event/[id].tsx
@@ -342,19 +342,14 @@ const Event = () => {
                       showTextEditDialog(EVENT_COMPONENT_TARGET.TITLE);
                     }}
                   ></_EventTitle>
-                  {ticketData?.rewardPolicy?.rewardPolicyType ===
-                  RewardPolicyType.Always ? (
-                    <EventDateRange ticketData={ticketData} />
-                  ) : (
-                    <_EventDateRange
-                      ticketData={ticketData}
-                      onClickForEdit={async (e) => {
-                        showDateEditDialog(
-                          EVENT_COMPONENT_TARGET.DATE_RANGE_TIME,
-                        );
-                      }}
-                    ></_EventDateRange>
-                  )}
+                  <_EventDateRange
+                    ticketData={ticketData}
+                    onClickForEdit={async (e) => {
+                      showDateEditDialog(
+                        EVENT_COMPONENT_TARGET.DATE_RANGE_TIME,
+                      );
+                    }}
+                  ></_EventDateRange>
                 </Stack>
               </Grid>
             </Grid>


### PR DESCRIPTION
리워드 정책이 상시 일 때, 이벤트 일정을 수정할 수 있게 변경했어요
리워드 정책을 상시에서 다른 정책으로 수정할 때, 일정 변경 이전까지 2100년으로 유저에게 노출되는것을 막기위해서 운영측에 일정 변경 후 정책 수정하도록 요청드리기 위함입니다