### PR TITLE
fix(#237): fix marketing term dialog z-index

### DIFF
--- a/src/layouts/dialog/sign/migration-dialog.tsx
+++ b/src/layouts/dialog/sign/migration-dialog.tsx
@@ -11,6 +11,7 @@ import MarketingAgreementForm from "@/components/form/signup/marketing-agreement
 import StringHelper from "@/helper/string-helper";
 import { useAlert } from "@/provider/alert/alert-provider";
 import { delay } from "@/util/timer";
+import { Z_INDEX_OFFSET } from "@/types";
 
 const MigrationDialog = ({
   onMigrationClick,
@@ -34,7 +35,7 @@ const MigrationDialog = ({
 
   return (
     <>
-      <SimpleDialog {...rest} maxWidth={"sm"} sx={{}}>
+      <SimpleDialog {...rest} maxWidth={"sm"}>
         <Stack sx={{ marginTop: 1 }} alignItems={"center"}>
           {address && (
             <>


### PR DESCRIPTION
Closes #237 
카카오 연동 모달에서 마케팅 수신 동의 모달이 보이지 않는 문제를 수정합니다
- MigrationDialog의 빈 sx prop이 SimpleDialog의 spread parameter 로 덮어 써져서 발생 *zIndex 가 덮어써짐