### PR TITLE
feat: upgrade kakao login

### DIFF
--- a/src/__generated__/gql.ts
+++ b/src/__generated__/gql.ts
@@ -26,6 +26,7 @@ const documents = {
     "\n  mutation CreateUserByKakao($kakaoInfo: KakaoInputType!) {\n    createUserByKakao(kakaoInfo: $kakaoInfo) {\n      name\n    }\n  }\n": types.CreateUserByKakaoDocument,
     "\n  mutation UpdateUserWalletByName(\n    $name: String!\n    $wallets: [UserWalletInputType!]\n  ) {\n    updateUserByName(name: $name, userUpdateInput: { wallets: $wallets }) {\n      wallets {\n        address\n        chain\n      }\n    }\n  }\n": types.UpdateUserWalletByNameDocument,
     "\n  mutation UpdateUserProfileImageByName(\n    $name: String!\n    $profileImageUrl: String!\n  ) {\n    updateUserByName(\n      name: $name\n      userUpdateInput: { profileImageUrl: $profileImageUrl }\n    ) {\n      profileImageUrl\n    }\n  }\n": types.UpdateUserProfileImageByNameDocument,
+    "\n  mutation UpdateUserAppAgreementByName(\n    $name: String!\n    $appAgreement: AppAgreementInputType!\n  ) {\n    updateUserByName(\n      name: $name\n      userUpdateInput: { appAgreement: $appAgreement }\n    ) {\n      appAgreement {\n        marketingPermission\n      }\n    }\n  }\n": types.UpdateUserAppAgreementByNameDocument,
     "\n  mutation UpdateUserEmailByName($name: String!, $email: String!) {\n    updateUserByName(name: $name, userUpdateInput: { email: $email }) {\n      email\n    }\n  }\n": types.UpdateUserEmailByNameDocument,
     "\n  mutation UpdateUserRewardByName($name: String!, $rewardPoint: Float!) {\n    updateUserByName(\n      name: $name\n      userUpdateInput: { rewardPoint: $rewardPoint }\n    ) {\n      rewardPoint\n    }\n  }\n": types.UpdateUserRewardByNameDocument,
     "\n  mutation UpdateUserSocialByName(\n    $name: String!\n    $userSocial: UserSocialInputType!\n  ) {\n    updateUserByName(\n      name: $name\n      userUpdateInput: { userSocial: $userSocial }\n    ) {\n      userSocial {\n        twitterId\n        telegramUser {\n          authDate\n          firstName\n          hash\n          id\n          photoUrl\n          username\n        }\n      }\n    }\n  }\n": types.UpdateUserSocialByNameDocument,
@@ -127,6 +128,10 @@ export function gql(source: "\n  mutation UpdateUserWalletByName(\n    $name: St
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function gql(source: "\n  mutation UpdateUserProfileImageByName(\n    $name: String!\n    $profileImageUrl: String!\n  ) {\n    updateUserByName(\n      name: $name\n      userUpdateInput: { profileImageUrl: $profileImageUrl }\n    ) {\n      profileImageUrl\n    }\n  }\n"): (typeof documents)["\n  mutation UpdateUserProfileImageByName(\n    $name: String!\n    $profileImageUrl: String!\n  ) {\n    updateUserByName(\n      name: $name\n      userUpdateInput: { profileImageUrl: $profileImageUrl }\n    ) {\n      profileImageUrl\n    }\n  }\n"];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function gql(source: "\n  mutation UpdateUserAppAgreementByName(\n    $name: String!\n    $appAgreement: AppAgreementInputType!\n  ) {\n    updateUserByName(\n      name: $name\n      userUpdateInput: { appAgreement: $appAgreement }\n    ) {\n      appAgreement {\n        marketingPermission\n      }\n    }\n  }\n"): (typeof documents)["\n  mutation UpdateUserAppAgreementByName(\n    $name: String!\n    $appAgreement: AppAgreementInputType!\n  ) {\n    updateUserByName(\n      name: $name\n      userUpdateInput: { appAgreement: $appAgreement }\n    ) {\n      appAgreement {\n        marketingPermission\n      }\n    }\n  }\n"];
 /**
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -16,6 +16,15 @@ export type Scalars = {
   DateTime: any;
 };
 
+export type AppAgreement = {
+  __typename?: 'AppAgreement';
+  marketingPermission: Scalars['Boolean'];
+};
+
+export type AppAgreementInputType = {
+  marketingPermission: Scalars['Boolean'];
+};
+
 export type AuthResponse = {
   __typename?: 'AuthResponse';
   accessToken?: Maybe<Scalars['String']>;
@@ -872,6 +881,7 @@ export enum TicketStatusType {
 export type User = {
   __typename?: 'User';
   _id?: Maybe<Scalars['String']>;
+  appAgreement?: Maybe<AppAgreement>;
   discord?: Maybe<Discord>;
   email?: Maybe<Scalars['String']>;
   gmail?: Maybe<Scalars['String']>;
@@ -881,12 +891,14 @@ export type User = {
   participatingTickets?: Maybe<Array<Ticket>>;
   profileImageUrl?: Maybe<Scalars['String']>;
   rewardPoint?: Maybe<Scalars['Float']>;
+  type?: Maybe<Scalars['String']>;
   userSocial?: Maybe<UserSocial>;
   wallets?: Maybe<Array<UserWallet>>;
 };
 
 export type UserInputType = {
   _id?: InputMaybe<Scalars['String']>;
+  appAgreement?: InputMaybe<AppAgreementInputType>;
   discord?: InputMaybe<DiscordInputType>;
   email?: InputMaybe<Scalars['String']>;
   gmail?: InputMaybe<Scalars['String']>;
@@ -896,6 +908,7 @@ export type UserInputType = {
   participatingTickets?: InputMaybe<Array<TicketInputType>>;
   profileImageUrl?: InputMaybe<Scalars['String']>;
   rewardPoint?: InputMaybe<Scalars['Float']>;
+  type?: InputMaybe<Scalars['String']>;
   userSocial?: InputMaybe<UserSocialInputType>;
   wallets?: InputMaybe<Array<UserWalletInputType>>;
 };
@@ -912,11 +925,13 @@ export type UserSocialInputType = {
 };
 
 export type UserUpdateInput = {
+  appAgreement?: InputMaybe<AppAgreementInputType>;
   discord?: InputMaybe<DiscordInputType>;
   email?: InputMaybe<Scalars['String']>;
   gmail?: InputMaybe<Scalars['String']>;
   profileImageUrl?: InputMaybe<Scalars['String']>;
   rewardPoint?: InputMaybe<Scalars['Float']>;
+  type?: InputMaybe<Scalars['String']>;
   userSocial?: InputMaybe<UserSocialInputType>;
   wallets?: InputMaybe<Array<UserWalletInputType>>;
 };
@@ -1027,6 +1042,14 @@ export type UpdateUserProfileImageByNameMutationVariables = Exact<{
 
 
 export type UpdateUserProfileImageByNameMutation = { __typename?: 'Mutation', updateUserByName: { __typename?: 'User', profileImageUrl?: string | null } };
+
+export type UpdateUserAppAgreementByNameMutationVariables = Exact<{
+  name: Scalars['String'];
+  appAgreement: AppAgreementInputType;
+}>;
+
+
+export type UpdateUserAppAgreementByNameMutation = { __typename?: 'Mutation', updateUserByName: { __typename?: 'User', appAgreement?: { __typename?: 'AppAgreement', marketingPermission: boolean } | null } };
 
 export type UpdateUserEmailByNameMutationVariables = Exact<{
   name: Scalars['String'];
@@ -1450,6 +1473,7 @@ export const CreateUserByWalletDocument = {"kind":"Document","definitions":[{"ki
 export const CreateUserByKakaoDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateUserByKakao"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"kakaoInfo"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"KakaoInputType"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createUserByKakao"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"kakaoInfo"},"value":{"kind":"Variable","name":{"kind":"Name","value":"kakaoInfo"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<CreateUserByKakaoMutation, CreateUserByKakaoMutationVariables>;
 export const UpdateUserWalletByNameDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateUserWalletByName"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"wallets"}},"type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UserWalletInputType"}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateUserByName"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}},{"kind":"Argument","name":{"kind":"Name","value":"userUpdateInput"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"wallets"},"value":{"kind":"Variable","name":{"kind":"Name","value":"wallets"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"wallets"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"address"}},{"kind":"Field","name":{"kind":"Name","value":"chain"}}]}}]}}]}}]} as unknown as DocumentNode<UpdateUserWalletByNameMutation, UpdateUserWalletByNameMutationVariables>;
 export const UpdateUserProfileImageByNameDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateUserProfileImageByName"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"profileImageUrl"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateUserByName"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}},{"kind":"Argument","name":{"kind":"Name","value":"userUpdateInput"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"profileImageUrl"},"value":{"kind":"Variable","name":{"kind":"Name","value":"profileImageUrl"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"profileImageUrl"}}]}}]}}]} as unknown as DocumentNode<UpdateUserProfileImageByNameMutation, UpdateUserProfileImageByNameMutationVariables>;
+export const UpdateUserAppAgreementByNameDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateUserAppAgreementByName"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"appAgreement"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AppAgreementInputType"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateUserByName"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}},{"kind":"Argument","name":{"kind":"Name","value":"userUpdateInput"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"appAgreement"},"value":{"kind":"Variable","name":{"kind":"Name","value":"appAgreement"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"appAgreement"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"marketingPermission"}}]}}]}}]}}]} as unknown as DocumentNode<UpdateUserAppAgreementByNameMutation, UpdateUserAppAgreementByNameMutationVariables>;
 export const UpdateUserEmailByNameDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateUserEmailByName"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"email"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateUserByName"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}},{"kind":"Argument","name":{"kind":"Name","value":"userUpdateInput"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"email"},"value":{"kind":"Variable","name":{"kind":"Name","value":"email"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"email"}}]}}]}}]} as unknown as DocumentNode<UpdateUserEmailByNameMutation, UpdateUserEmailByNameMutationVariables>;
 export const UpdateUserRewardByNameDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateUserRewardByName"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"rewardPoint"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Float"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateUserByName"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}},{"kind":"Argument","name":{"kind":"Name","value":"userUpdateInput"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"rewardPoint"},"value":{"kind":"Variable","name":{"kind":"Name","value":"rewardPoint"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"rewardPoint"}}]}}]}}]} as unknown as DocumentNode<UpdateUserRewardByNameMutation, UpdateUserRewardByNameMutationVariables>;
 export const UpdateUserSocialByNameDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateUserSocialByName"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"userSocial"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UserSocialInputType"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateUserByName"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}},{"kind":"Argument","name":{"kind":"Name","value":"userUpdateInput"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"userSocial"},"value":{"kind":"Variable","name":{"kind":"Name","value":"userSocial"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userSocial"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"twitterId"}},{"kind":"Field","name":{"kind":"Name","value":"telegramUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"authDate"}},{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"hash"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"photoUrl"}},{"kind":"Field","name":{"kind":"Name","value":"username"}}]}}]}}]}}]}}]} as unknown as DocumentNode<UpdateUserSocialByNameMutation, UpdateUserSocialByNameMutationVariables>;

--- a/src/components/atomic/atoms/term-agree-item.tsx
+++ b/src/components/atomic/atoms/term-agree-item.tsx
@@ -1,0 +1,28 @@
+import { Box, Button, Checkbox, FormControlLabel, Link } from "@mui/material";
+import { PropsWithChildren } from "react";
+
+interface TermAgreeItemProps extends PropsWithChildren {
+  checked: boolean;
+  termLink?: string;
+  onChangeCheck?(event: React.ChangeEvent<HTMLInputElement>): void;
+}
+
+function TermAgreeItem(props: TermAgreeItemProps) {
+  const { checked, termLink, onChangeCheck } = props;
+
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", minWidth: 280 }}>
+      <FormControlLabel
+        label={props.children}
+        control={<Checkbox checked={checked} onChange={onChangeCheck} />}
+      />
+      {termLink && (
+        <Link href={termLink} target="_blank" sx={{ ml: "auto" }}>
+          보기
+        </Link>
+      )}
+    </Box>
+  );
+}
+
+export default TermAgreeItem;

--- a/src/components/form/signup/marketing-agreement-form.tsx
+++ b/src/components/form/signup/marketing-agreement-form.tsx
@@ -1,19 +1,7 @@
-import {
-  Box,
-  Checkbox,
-  FormControlLabel,
-  Stack,
-  Tooltip,
-  Typography,
-} from "@mui/material";
-import { index } from "@zxing/text-encoding/es2015/encoding/indexes";
-import { e } from "msw/lib/glossary-de6278a9";
+import { Box, Checkbox, FormControlLabel, Stack } from "@mui/material";
 import React, { useEffect, useState } from "react";
 
-import ClickTyphography from "@/components/atomic/atoms/click-typhography";
-import PrimaryButton from "@/components/atomic/atoms/primary-button";
-import SimpleDialog from "@/components/dialogs/simple-dialog";
-import { useAlert } from "@/provider/alert/alert-provider";
+import TermAgreeItem from "@/components/atomic/atoms/term-agree-item";
 
 const MarketingAgreementForm = ({
   defaultValue = false,
@@ -22,9 +10,7 @@ const MarketingAgreementForm = ({
   defaultValue?: boolean;
   onChangedValue?: (checked: boolean[]) => void;
 }) => {
-  const { showAlert } = useAlert();
   const [checkedList, setCheckedList] = useState([defaultValue, defaultValue]);
-  const [openSubDialogList, setOpenSubDialogList] = useState([false, false]);
 
   useEffect(() => {
     onChangedValue?.(checkedList);
@@ -50,93 +36,35 @@ const MarketingAgreementForm = ({
                 />
               }
             />
-            <Box sx={{ display: "flex", flexDirection: "column", ml: 3 }}>
-              <Stack direction={"row"} alignItems={"center"}>
-                <FormControlLabel
-                  label=""
-                  control={
-                    <Checkbox
-                      checked={checkedList[0]}
-                      onChange={(
-                        event: React.ChangeEvent<HTMLInputElement>,
-                      ) => {
-                        setCheckedList([event.target.checked, checkedList[1]]);
-                      }}
-                    />
-                  }
-                />
-                <Box sx={{ marginLeft: -2 }}>
-                  <Tooltip title={"마케팅 수신 동의 - 1"}>
-                    <Box>
-                      <ClickTyphography
-                        onClick={(e) => {
-                          setOpenSubDialogList((prevState) => {
-                            return [true, prevState[1]];
-                          });
-                        }}
-                      >
-                        마케팅 수신 동의 - 1
-                      </ClickTyphography>
-                    </Box>
-                  </Tooltip>
-                </Box>
-              </Stack>
-              <Stack direction={"row"} alignItems={"center"}>
-                <FormControlLabel
-                  label=""
-                  control={
-                    <Checkbox
-                      checked={checkedList[1]}
-                      onChange={(
-                        event: React.ChangeEvent<HTMLInputElement>,
-                      ) => {
-                        setCheckedList([checkedList[0], event.target.checked]);
-                      }}
-                    />
-                  }
-                />
-                <Box sx={{ marginLeft: -2 }}>
-                  <Tooltip title={"마케팅 수신 동의 - 2"}>
-                    <Box>
-                      <ClickTyphography
-                        onClick={(e) => {
-                          setOpenSubDialogList((prevState) => {
-                            return [prevState[0], true];
-                          });
-                        }}
-                      >
-                        마케팅 수신 동의 - 2
-                      </ClickTyphography>
-                    </Box>
-                  </Tooltip>
-                </Box>
-              </Stack>
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                ml: 3,
+              }}
+            >
+              <TermAgreeItem
+                checked={checkedList[0]}
+                termLink="/term/kakao"
+                onChangeCheck={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  setCheckedList([event.target.checked, checkedList[1]]);
+                }}
+              >
+                (필수) 개인정보 수집·이용 동의
+              </TermAgreeItem>
+              <TermAgreeItem
+                checked={checkedList[1]}
+                termLink="/term/kakao"
+                onChangeCheck={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  setCheckedList([checkedList[0], event.target.checked]);
+                }}
+              >
+                (선택) 마케팅 정보 수신 동의
+              </TermAgreeItem>
             </Box>
           </div>
         </Stack>
       </Stack>
-      <SimpleDialog
-        open={openSubDialogList[0]}
-        title={"마케팅 수신 동의 - 1"}
-        onCloseBtnClicked={(e) => {
-          setOpenSubDialogList((prevState) => {
-            return [false, prevState[1]];
-          });
-        }}
-      >
-        <Typography>마케팅 수신 동의</Typography>
-      </SimpleDialog>
-      <SimpleDialog
-        open={openSubDialogList[1]}
-        title={"마케팅 수신 동의 - 2"}
-        onCloseBtnClicked={(e) => {
-          setOpenSubDialogList((prevState) => {
-            return [prevState[0], false];
-          });
-        }}
-      >
-        <Typography>마케팅 수신 동의</Typography>
-      </SimpleDialog>
     </>
   );
 };

--- a/src/hooks/signed-user-query-hook.tsx
+++ b/src/hooks/signed-user-query-hook.tsx
@@ -3,9 +3,11 @@ import { useEffect, useRef, useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 
 import {
+  AppAgreementInputType,
   ChainType,
   DiscordInputType,
   KakaoInputType,
+  UserUpdateInput,
 } from "../__generated__/graphql";
 import {
   APP_ERROR_MESSAGE,
@@ -35,6 +37,7 @@ import {
   UPDATE_USER_TELEGRAM_BY_NAME,
   UPDATE_USER_WALLET_BY_NAME,
   CREATE_USER_BY_KAKAO,
+  UPDATE_USER_APP_AGREEMENT_BY_NAME,
 } from "../lib/apollo/query";
 import { userDataState } from "../lib/recoil";
 import { useAlert } from "../provider/alert/alert-provider";
@@ -88,6 +91,9 @@ const useSignedUserQuery = () => {
   const [UpdateUserTelegramByName] = useMutation(UPDATE_USER_TELEGRAM_BY_NAME);
   const [UpdateUserRewardByName] = useMutation(UPDATE_USER_REWARD_BY_NAME);
   const [UpdateUserSocialByName] = useMutation(UPDATE_USER_SOCIAL_BY_NAME);
+  const [UpdateUserAppAgreementByName] = useMutation(
+    UPDATE_USER_APP_AGREEMENT_BY_NAME,
+  );
   const [UpdateKakaoByName] = useMutation(UPDATE_KAKAO_BY_NAME);
   const [DeleteKakaoByName] = useMutation(DELETE_KAKAO_BY_NAME);
   const [CreateUserByKakao] = useMutation(CREATE_USER_BY_KAKAO);
@@ -550,6 +556,31 @@ const useSignedUserQuery = () => {
     }
   };
 
+  const asyncUpdateAppAgreement = async (
+    input: Required<Pick<UserUpdateInput, "appAgreement">> &
+      Partial<Pick<User, "name">>,
+  ) => {
+    try {
+      if (!input.appAgreement) return;
+      if (!input.name && !userData.name) return;
+
+      await UpdateUserAppAgreementByName({
+        variables: {
+          name: input.name || userData.name!,
+          appAgreement: input.appAgreement,
+        },
+      });
+      setUserData((prevState: User) => {
+        return {
+          ...prevState,
+          appAgreement: input,
+        };
+      });
+    } catch (e) {
+      throw new AppError(getErrorMessage(e));
+    }
+  };
+
   const asyncUpdateSocialTwitter = async (twitterId: string) => {
     console.log(twitterId, userData.userSocial?.telegramUser);
     try {
@@ -760,6 +791,8 @@ const useSignedUserQuery = () => {
       },
     });
     await asyncUpdateCachedKakaoUserInfo(kakaoUserInfo);
+
+    return res.data?.createUserByKakao;
   };
 
   return {
@@ -770,6 +803,7 @@ const useSignedUserQuery = () => {
     asyncUpdateEmail,
     asyncUpdateSocialTwitter,
     asyncUpdateRewardPoint,
+    asyncUpdateAppAgreement,
     asyncDeleteWalletAddress,
     asyncUpdateSocialTelegram,
     asyncRemoveSocialTelegram,

--- a/src/layouts/dialog/sign/account-create-alert-dialog.tsx
+++ b/src/layouts/dialog/sign/account-create-alert-dialog.tsx
@@ -1,5 +1,5 @@
 import { Stack, Typography } from "@mui/material";
-import React, { MouseEventHandler, useState } from "react";
+import React, { MouseEvent, useState } from "react";
 
 import PrimaryButton from "@/components/atomic/atoms/primary-button";
 import SimpleDialog, {
@@ -12,7 +12,10 @@ const AccountCreateAlertDialog = ({
   onCreateAccountClick,
   ...rest
 }: {
-  onCreateAccountClick?: MouseEventHandler;
+  onCreateAccountClick?(
+    e: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>,
+    isAgreeMarketingTerm: boolean,
+  ): void;
 } & SimpleDialogProps) => {
   const [checkedList, setCheckedList] = useState([false, false]);
   const { showAlert } = useAlert();
@@ -35,7 +38,7 @@ const AccountCreateAlertDialog = ({
                 });
                 return;
               }
-              onCreateAccountClick?.(e);
+              onCreateAccountClick?.(e, checkedList[1]);
             }}
           >
             예, 생성하겠습니다.

--- a/src/layouts/dialog/sign/migration-dialog.tsx
+++ b/src/layouts/dialog/sign/migration-dialog.tsx
@@ -1,5 +1,10 @@
 import { Box, CircularProgress, Stack, Typography } from "@mui/material";
-import React, { MouseEventHandler, useEffect, useState } from "react";
+import React, {
+  MouseEvent,
+  MouseEventHandler,
+  useEffect,
+  useState,
+} from "react";
 
 import GradientTypography from "@/components/atomic/atoms/gradient-typography";
 import PrimaryButton from "@/components/atomic/atoms/primary-button";
@@ -11,7 +16,6 @@ import MarketingAgreementForm from "@/components/form/signup/marketing-agreement
 import StringHelper from "@/helper/string-helper";
 import { useAlert } from "@/provider/alert/alert-provider";
 import { delay } from "@/util/timer";
-import { Z_INDEX_OFFSET } from "@/types";
 
 const MigrationDialog = ({
   onMigrationClick,
@@ -19,7 +23,10 @@ const MigrationDialog = ({
   ...rest
 }: {
   address?: string;
-  onMigrationClick?: MouseEventHandler;
+  onMigrationClick?(
+    e: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>,
+    isAgreeMarketingTerm: boolean,
+  ): void;
 } & SimpleDialogProps) => {
   const [checkedList, setCheckedList] = useState([false, false]);
   const [loading, setLoading] = useState(true);
@@ -55,7 +62,7 @@ const MigrationDialog = ({
                       });
                       return;
                     }
-                    onMigrationClick?.(e);
+                    onMigrationClick?.(e, checkedList[1]);
                   }}
                 >
                   해당 계정으로 카카오 연동하기

--- a/src/layouts/main-layout.tsx
+++ b/src/layouts/main-layout.tsx
@@ -94,6 +94,7 @@ const MainLayout = (props: MainLayoutProps) => {
     userData,
     asyncKakaoLogin,
     asyncUpdateKakao,
+    asyncUpdateAppAgreement,
     asyncCreateUserByKakaoInfo,
   } = useSignedUserQuery();
   const { setShowSignInDialog, isSignDialogOpen } = useSignDialog();
@@ -503,9 +504,14 @@ const MainLayout = (props: MainLayoutProps) => {
           await asyncLogoutBtnOnClick();
           setOpenMigrationDialog(false);
         }}
-        onMigrationClick={async (e) => {
+        onMigrationClick={async (e, isAgreeMarketingTerm) => {
           showLoading();
           await asyncUpdateKakao();
+          await asyncUpdateAppAgreement({
+            appAgreement: {
+              marketingPermission: isAgreeMarketingTerm,
+            },
+          });
           setOpenMigrationDialog(false);
           closeLoading();
         }}
@@ -513,10 +519,16 @@ const MainLayout = (props: MainLayoutProps) => {
       <AccountCreateAlertDialog
         open={openAccountCreateAlertDialog}
         title={"알림"}
-        onCreateAccountClick={async (e) => {
+        onCreateAccountClick={async (e, isAgreeMarketingTerm) => {
           try {
             showLoading();
-            await asyncCreateUserByKakaoInfo();
+            const kakaoInfo = await asyncCreateUserByKakaoInfo();
+            await asyncUpdateAppAgreement({
+              name: kakaoInfo?.name || undefined,
+              appAgreement: {
+                marketingPermission: isAgreeMarketingTerm,
+              },
+            });
             setOpenAccountCreateAlertDialog(false);
             closeLoading();
           } catch (e) {

--- a/src/lib/apollo/query.tsx
+++ b/src/lib/apollo/query.tsx
@@ -416,6 +416,22 @@ export const UPDATE_USER_PROFILE_IMAGE_URL_BY_NAME = gql(/* GraphQL */ `
   }
 `);
 
+export const UPDATE_USER_APP_AGREEMENT_BY_NAME = gql(/* GraphQL */ `
+  mutation UpdateUserAppAgreementByName(
+    $name: String!
+    $appAgreement: AppAgreementInputType!
+  ) {
+    updateUserByName(
+      name: $name
+      userUpdateInput: { appAgreement: $appAgreement }
+    ) {
+      appAgreement {
+        marketingPermission
+      }
+    }
+  }
+`);
+
 export const UPDATE_USER_BY_EMAIL = gql(/* GraphQL */ `
   mutation UpdateUserEmailByName($name: String!, $email: String!) {
     updateUserByName(name: $name, userUpdateInput: { email: $email }) {

--- a/src/pages/term/kakao.tsx
+++ b/src/pages/term/kakao.tsx
@@ -1,0 +1,113 @@
+import {
+  Link,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import Head from "next/head";
+import { ReactElement } from "react";
+
+import MainLayout from "@/layouts/main-layout";
+
+function TermKakao() {
+  return (
+    <>
+      <Head>
+        <title>3ridge : Web3 온보딩 플랫폼</title>
+      </Head>
+      <div className="mx-auto mt-20 max-w-7xl px-20">
+        <Typography typography={"h3"}>카카오 계정 연동 약관</Typography>
+        <hr className="mb-10" />
+        <div>
+          <Typography typography={"h5"}>
+            (필수) 개인정보 수집·이용 동의
+          </Typography>
+          <Typography className="mt-5">
+            당사는 귀하의 개인정보를 수집하고 저장하기 위해 아래와 같은 항목을
+            수집하고자 합니다. 동의하지 않을 경우 관련 서비스의 이용이 제한될 수
+            있습니다. 더 자세한 정보나 궁금한 사항이 있으신 경우{" "}
+            <Link href="mailto:support@3ridge.io">support@3ridge.io</Link>로
+            연락 주시기 바랍니다.
+          </Typography>
+          <Table className="mt-5">
+            <TableBody>
+              <TableRow>
+                <TableCell sx={{ fontWeight: 600 }}>
+                  개인정보 수집 항목
+                </TableCell>
+                <TableCell>
+                  카카오 계정, 이메일, 트위터, 디스코드 ID, 전화번호, 지갑 주소
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell sx={{ fontWeight: 600 }}>
+                  이용 및 수집 목적
+                </TableCell>
+                <TableCell>
+                  이벤트 정보 및 경품 제공, 온체인 데이터 가공
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell sx={{ fontWeight: 600 }}>
+                  보유 및 이용 기간
+                </TableCell>
+                <TableCell>계정 탈퇴 후 1년까지</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </div>
+        <div className="mt-20">
+          <Typography typography={"h5"}>
+            (선택) 마케팅 정보 수신 동의
+          </Typography>
+          <Typography className="mt-5">
+            당사는 귀하의 개인정보를 안전하게 보호하고 최신 이벤트 정보, 특별
+            프로모션, 경품 제공 등의 서비스를 제공하기 위해 마케팅 정보 수신
+            동의를 받고자 합니다. 더 자세한 정보나 궁금한 사항이 있으신 경우{" "}
+            <Link href="mailto:support@3ridge.io">support@3ridge.io</Link>로
+            연락 주시기 바랍니다.
+          </Typography>
+          <Typography>
+            (마케팅 정보 수신에 동의하지 않을 경우 이벤트 상품을 수령하실 수
+            없습니다)
+          </Typography>
+          <Table className="mt-5">
+            <TableBody>
+              <TableRow>
+                <TableCell sx={{ fontWeight: 600 }}>
+                  개인정보 수집 항목
+                </TableCell>
+                <TableCell>
+                  카카오 계정, 이메일, 트위터, 디스코드 ID, 지갑 주소, 전화번호,
+                  마케팅 수신 동의 여부
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell sx={{ fontWeight: 600 }}>
+                  이용 및 수집 목적
+                </TableCell>
+                <TableCell>
+                  이벤트 정보 및 경품 제공, 온체인 데이터 가공
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell sx={{ fontWeight: 600 }}>
+                  보유 및 이용 기간
+                </TableCell>
+                <TableCell>계정 탈퇴 후 1년까지</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </>
+  );
+}
+
+TermKakao.getLayout = (page: ReactElement | ReactElement[]) => (
+  <MainLayout>{page}</MainLayout>
+);
+
+export default TermKakao;


### PR DESCRIPTION
Fixes #250 

카카오톡 연동 시 수집해야하는 마케팅 동의 약관을 노출하는 태스크입니다
약관동의 체크박스 옆에 보기 링크를 추가했으며, 클릭시 새 창으로 약관페이지를 보여줍니다 (href: '/term/kakao', target: 'blank')
또한, 마케팅 정보 수신 동의 여부를 db에 적재합니다
약관 동의 이후 작업*은 분리해서 진행할 예정입니다
*(필수만 동의해도 진행되도록 변경, 선택 약관 미동의 시 사용자에게 팝업 노출)